### PR TITLE
Fixed support for the customer object number

### DIFF
--- a/lib/models/requests/customer.dart
+++ b/lib/models/requests/customer.dart
@@ -2,17 +2,18 @@ import '../../utils.dart';
 
 class Customer {
   String email;
-  String? phoneNumber;
-  String? name;
+  String phoneNumber;
+  String name;
 
-  Customer({required this.email, this.name, this.phoneNumber});
+  Customer(
+      {required this.name, required this.phoneNumber, required this.email});
 
   /// Converts instance of Customer to json
   Map<String, dynamic> toJson() {
-    final customer =  {
+    final customer = {
       "email": this.email,
-      "phonenumber": this.phoneNumber ?? "",
-      "name": this.name ?? ""
+      "phone_number": this.phoneNumber,
+      "name": this.name
     };
     return Utils.removeKeysWithEmptyValues(customer);
   }

--- a/lib/models/requests/standard_request.dart
+++ b/lib/models/requests/standard_request.dart
@@ -23,18 +23,19 @@ class StandardRequest {
   List<SubAccount>? subAccounts;
   Map<dynamic, dynamic>? meta;
 
-  StandardRequest({required this.txRef,
-    required this.amount,
-    required this.customer,
-    required this.paymentOptions,
-    required this.customization,
-    required this.isTestMode,
-    required this.publicKey,
-    required this.redirectUrl,
-    this.currency,
-    this.paymentPlanId,
-    this.subAccounts,
-    this.meta});
+  StandardRequest(
+      {required this.txRef,
+      required this.amount,
+      required this.customer,
+      required this.paymentOptions,
+      required this.customization,
+      required this.isTestMode,
+      required this.publicKey,
+      required this.redirectUrl,
+      this.currency,
+      this.paymentPlanId,
+      this.subAccounts,
+      this.meta});
 
   String toString() => jsonEncode(this._toJson());
 
@@ -53,6 +54,7 @@ class StandardRequest {
       "meta": this.meta,
       "customizations": customization.toJson()
     };
+    print(this.customer.toJson());
     return Utils.removeKeysWithEmptyValues(request);
   }
 


### PR DESCRIPTION
when building the flutterwave object for a mobile money payment, the customer number entered was not supported at the generated interface.